### PR TITLE
VINS: Fix incorrect header in arducam_pose topic

### DIFF
--- a/VINS_GPU/src/VINS-GPU/vins_estimator/src/utility/visualization.cpp
+++ b/VINS_GPU/src/VINS-GPU/vins_estimator/src/utility/visualization.cpp
@@ -302,7 +302,7 @@ void pubCameraPose(const Estimator &estimator, const std_msgs::Header &header)
        
        //**
        geometry_msgs::PoseStamped new_pose;     
-       new_pose.header.stamp =  odometry.header.stamp;
+       new_pose.header =  odometry.header;
        new_pose.pose =  odometry.pose.pose;
        pub_arducam_pose.publish(new_pose);
        //**


### PR DESCRIPTION
This fixes a small typo in the arducam_pose topic in VINS.

Currently, the pose topic header is incorrect, leading to an empty frame_id.